### PR TITLE
Add parameter to override source name

### DIFF
--- a/macros/sfdc_formula_pivot.sql
+++ b/macros/sfdc_formula_pivot.sql
@@ -1,6 +1,6 @@
-{%- macro sfdc_formula_pivot(join_to_table) -%}
+{%- macro sfdc_formula_pivot(join_to_table, source_name='salesforce') -%}
 
-    {%- set key_val = salesforce_formula_utils.sfdc_get_formula_column_values(source('salesforce', 'fivetran_formula'), 'field', 'sql', join_to_table) -%}
+    {%- set key_val = salesforce_formula_utils.sfdc_get_formula_column_values(source(source_name, 'fivetran_formula'), 'field', 'sql', join_to_table) -%}
 
     {% for k, v in key_val %}
         {% if v == 'null_value' %}

--- a/macros/sfdc_formula_view.sql
+++ b/macros/sfdc_formula_view.sql
@@ -1,4 +1,4 @@
-{%- macro sfdc_formula_view(join_to_table_first) -%}
+{%- macro sfdc_formula_view(join_to_table_first, source_name='salesforce') -%}
 
 {{
     config(
@@ -6,11 +6,11 @@
     )
 }}
 
-{%- set old_formula_fields = dbt_utils.get_column_values(source('salesforce', 'fivetran_formula'),'field') -%}
+{%- set old_formula_fields = dbt_utils.get_column_values(source(source_name, 'fivetran_formula'),'field') -%}
     
     select 
-        {{ dbt_utils.star(source('salesforce',join_to_table_first), except=old_formula_fields) }},
+        {{ dbt_utils.star(source(source_name,join_to_table_first), except=old_formula_fields) }},
         {{ salesforce_formula_utils.sfdc_formula_pivot(join_to_table=join_to_table_first) }}
-    from {{ source('salesforce',join_to_table_first) }}
+    from {{ source(source_name,join_to_table_first) }}
 
 {%- endmacro -%}


### PR DESCRIPTION
**Are you a current Fivetran customer?** 
Yes

**What change(s) does this PR introduce?** 
Add a `source_name` parameter with a default value of 'salesforce' to allow the macros to run on multiple sources in a project.

**Does this PR introduce a breaking change?**
<!--- Does this PR introduce changes that -->
<!--- Mark yes or no (eg. [x] Yes). If yes, link the issue. -->
- [ ] Yes (please provide breaking change details below.)
- [x] No  (please provide explanation how the change is non breaking below.)

The parameter is optional with a default value that matches the hard-coded value used previously. 

**Is this PR in response to a previously created Issue**
<!--- If an Issue was created it is helpful to track the progress by linking it in the PR. -->
<!--- Mark yes or no (eg. [x] Yes). If yes, link the issue. -->
- [x] Yes, Issue #6 
- [ ] No 

**How did you test the PR changes?** 
<!--- Proof of testing is required in order for the PR to be approved. -->
<!--- To check a box, remove the space and insert an x in the box (eg. [x] CircleCi). --> 
- [ ] CircleCi <!--- CircleCi testing is only applicable to Fivetran employees. --> 
- [x] Other (please provide additional testing details below)

Tested with our sources in Snowflake including a default 'salesforce' source.

**Select which warehouse(s) were used to test the PR**
<!--- To check a warehouse remove the space and insert an x in the box (eg. [x] Bigquery). --> 
- [ ] BigQuery
- [ ] Redshift
- [x] Snowflake
- [ ] Postgres
- [ ] Databricks
- [ ] Other (provide details below)

**Provide an emoji that best describes your current mood**
<!--- For a complete list of markdown compatible emojis check our this git repo (https://gist.github.com/rxaviers/7360908)  --> 
:construction_worker:


