### PR TITLE
Removed lower casing for more accurate sql translation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# dbt_salesforce_formula_utils v0.6.1
+## Bug Fixes
+- Formulas were previously being lower cased within the macro to be consistent across the board. However, this resulted in some translations to be incorrect if they required specific casing. A fix has been implemented to rely on the casing within the `fivetran_formula` table instead of casing within the macro. ((#37)[https://github.com/fivetran/dbt_salesforce_formula_utils/pull/37])
+
 # dbt_salesforce_formula_utils v0.6.0
 🎉 dbt v1.0.0 Compatibility 🎉
 ## 🚨 Breaking Changes 🚨

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'salesforce_formula_utils'
-version: '0.6.0'
+version: '0.6.1'
 config-version: 2
 
 require-dbt-version: [">=1.0.0", "<2.0.0"]

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,6 +1,6 @@
 
 name: 'salesforce_formula_integration_tests'
-version: '0.5.1'
+version: '0.6.1'
 profile: 'integration_tests'
 config-version: 2
 

--- a/macros/sfdc_get_formula_column_values.sql
+++ b/macros/sfdc_get_formula_column_values.sql
@@ -20,10 +20,10 @@
         {%- else -%}
             -- Query used to obtain the unique groupings for key (field) and value (sql) from the formula_field table
             select
-                lower( {{ key }} ) as key,
+                {{ key }} as key,
                 case when {{ value }} is null
                     then 'null_value'               -- Since none type values cannot be iterated over in a dataframe, this is set to string 'null_value' and is changed later back to null.
-                    else lower( {{ value }} )
+                    else {{ value }}
                         end as value
             from {{ target_relation }}
             where lower(object) = lower('{{ join_to_table }}')    -- This filters the query to only include the formula fields referenced by the source table.


### PR DESCRIPTION
**Are you a current Fivetran customer?** 
<!--- Please tell us your name, title and company -->
Fivetran created PR

**What change(s) does this PR introduce?** 
<!--- Describe what changes your PR introduces to the package -->
This PR removes the `lower` filters from the get_column macro within this package. The `lower` filter was incorrectly translating the sql and thus resulting in incorrect formulas. With the removal of the lower filters in the specified locations, the sql will be translated correctly.

**Does this PR introduce a breaking change?**
<!--- Does this PR introduce changes that -->
<!--- Mark yes or no (eg. [x] Yes). If yes, link the issue. -->
- [ ] Yes (please provide breaking change details below.)
- [X] No  (please provide explanation how the change is non breaking below.)

This is only a bug fix that will not impact current users of the package. As such, this will not be a breaking change.

**Is this PR in response to a previously created Issue**
<!--- If an Issue was created it is helpful to track the progress by linking it in the PR. -->
<!--- Mark yes or no (eg. [x] Yes). If yes, link the issue. -->
- [X] Yes, Issue #34 
- [ ] No 

**How did you test the PR changes?** 
<!--- Proof of testing is required in order for the PR to be approved. -->
<!--- To check a box, remove the space and insert an x in the box (eg. [x] CircleCi). --> 
- [ ] CircleCi <!--- CircleCi testing is only applicable to Fivetran employees. --> 
- [ ] Other (please provide additional testing details below)

**Select which warehouse(s) were used to test the PR**
<!--- To check a warehouse remove the space and insert an x in the box (eg. [x] Bigquery). --> 
- [X] BigQuery
- [X] Redshift
- [X] Snowflake
- [X] Postgres
- [ ] Databricks
- [ ] Other (provide details below)

**Provide an emoji that best describes your current mood**
<!--- For a complete list of markdown compatible emojis check our this git repo (https://gist.github.com/rxaviers/7360908)  --> 
🕴️ 

**Feedback**

We are so excited you decided to contribute to the Fivetran community dbt package! We continue to work to improve the packages and would greatly appreciate your [feedback](https://www.surveymonkey.com/r/DQ7K7WW) on our existing dbt packages or what you'd like to see next.
