### PR TITLE
feature/table-alias-removal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# dbt_salesforce_formula_utils v0.6.4
+## Under the Hood
+- The string `__table` is now prepended to the table alias to match with the data provided within the connector. To ensure consistency across the board, the `reserved_table_name` argument is now ignored in place of the `{{source_table}}__table` format.
+  - The `reserved_table_name` argument is still accepted, but is just ignored for the time being. This will be removed in the next breaking release.
 # dbt_salesforce_formula_utils v0.6.3
 ## Fixes
 - Adjusted the conditional within the `sfdc_formula_views` macro to reference the properly named `current_formula_fields` variable opposed to the incorrect `old_formula_fields` variable that is not longer referenced. ([#46](https://github.com/fivetran/dbt_salesforce_formula_utils/pull/46))

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'salesforce_formula_utils'
-version: '0.6.3'
+version: '0.6.4'
 config-version: 2
 
 require-dbt-version: [">=1.0.0", "<2.0.0"]

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,6 +1,6 @@
 
 name: 'salesforce_formula_integration_tests'
-version: '0.6.3'
+version: '0.6.4'
 profile: 'integration_tests'
 config-version: 2
 

--- a/macros/sfdc_formula_view.sql
+++ b/macros/sfdc_formula_view.sql
@@ -22,14 +22,14 @@
 
     select
 
-        {{ salesforce_formula_utils.sfdc_star_exact(source(source_name,source_table), relation_alias=reserved_table_name, except=current_formula_fields) }} --Querying the source table and excluding the old formula fields if they are present.
+        {{ salesforce_formula_utils.sfdc_star_exact(source(source_name,source_table), relation_alias=(source_table + "__table"), except=current_formula_fields) }} --Querying the source table and excluding the old formula fields if they are present.
 
         {{ salesforce_formula_utils.sfdc_formula_view_fields(join_to_table=source_table, source_name=source_name, inclusion_fields=fields_to_include) }} --Adds the field names for records that leverage the view_sql logic.
 
         {{ salesforce_formula_utils.sfdc_formula_pivot(join_to_table=source_table, source_name=source_name, added_inclusion_fields=fields_to_include) }} --Adds the results of the sfdc_formula_pivot macro as the remainder of the sql query.
 
-    from {{ source(source_name,source_table) }} as {{ reserved_table_name }}
+    from {{ source(source_name,source_table) }} as {{ source_table }}__table
 
-    {{ salesforce_formula_utils.sfdc_formula_view_sql(join_to_table=source_table, source_name=source_name, reserved_table_name=reserved_table_name, inclusion_fields=fields_to_include) }} --If view_sql logic is used, queries are inserted here as well as the where clause.
+    {{ salesforce_formula_utils.sfdc_formula_view_sql(join_to_table=source_table, source_name=source_name, inclusion_fields=fields_to_include) }} --If view_sql logic is used, queries are inserted here as well as the where clause.
 
 {%- endmacro -%}

--- a/macros/sfdc_formula_view_sql.sql
+++ b/macros/sfdc_formula_view_sql.sql
@@ -1,4 +1,4 @@
-{%- macro sfdc_formula_view_sql(join_to_table, source_name = 'salesforce', reserved_table_name=join_to_table, inclusion_fields=none, not_null_value=true) -%}
+{%- macro sfdc_formula_view_sql(join_to_table, source_name = 'salesforce', reserved_table_name=source_table, inclusion_fields=none, not_null_value=true) -%}
 
     --Generate the key value pair from the formula field table with the below macro.
     {%- set key_val = salesforce_formula_utils.sfdc_get_formula_column_values(source(source_name, 'fivetran_formula'), 'field', 'view_sql', join_to_table, not_null_value) -%}
@@ -32,7 +32,7 @@
 
         --A where clause is needed to properly leverage the view sql. The below joins the views to the base table using the base ID.
         {%- for lookup in view_sql_ref %}
-            {% if loop.first %}where {% endif %} {{ reserved_table_name }}.id = view_sql_{{ lookup }}.id
+            {% if loop.first %}where {% endif %} {{ join_to_table }}__table.id = view_sql_{{ lookup }}.id
             {% if not loop.last %}
             and {% endif %}
         {% endfor -%}


### PR DESCRIPTION
**Are you a current Fivetran customer?** 
<!--- Please tell us your name, title and company -->
Fivetran created PR

**What change(s) does this PR introduce?** 
<!--- Describe what changes your PR introduces to the package and how to leverage this new feature. -->
The string `__table` is now prepended to the table alias to match with the data provided within the connector. To ensure consistency across the board, the `reserved_table_name` argument is now ignored in place of the `{{source_table}}__table` format.
  - The `reserved_table_name` argument is still accepted, but is just ignored for the time being. This will be removed in the next breaking release.


**Did you update the CHANGELOG?** 
<!--- Please update the new package version’s CHANGELOG entry detailing the changes included in this PR. -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [X] Yes

**Does this PR introduce a breaking change?**
<!--- Does this PR introduce changes that will cause current package users' jobs to fail or require a `--full-refresh`? -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] Yes (please provide breaking change details below.)
- [X] No  (please provide an explanation as to how the change is non-breaking below.)

This change is intentionally not a breaking change as it is meant to coincide with a release of the connector update and should organically pick up the changes without breaking existing runs.

**Did you update the dbt_project.yml files with the version upgrade (please leverage standard semantic versioning)? (In both your main project and integration_tests)** 
<!--- The dbt_project.yml and the integration_tests/dbt_project.yml files contain the version number. Be sure to upgrade it accordingly -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [X] Yes

**Is this PR in response to a previously created Bug or Feature Request**
<!--- If an Issue was created it is helpful to track the progress by linking it in the PR. -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] Yes, Issue/Feature [link bug/feature number here]
- [ ] No 

**How did you test the PR changes?** 
<!--- Proof of testing is required in order for the PR to be approved. -->
<!--- To check a box, remove the space and insert an x in the box (eg. [x] CircleCi). --> 
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [X] CircleCi <!--- CircleCi testing is only applicable to Fivetran employees. --> 
- [X] Local (please provide additional testing details below)

Tested this locally and was able to see the updates work as intended.

**Select which warehouse(s) were used to test the PR**
<!--- To check a warehouse remove the space and insert an x in the box (eg. [x] Bigquery). --> 
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [X] BigQuery
- [X] Redshift
- [X] Snowflake
- [X] Postgres
- [ ] Databricks
- [ ] Other (provide details below)

**Provide an emoji that best describes your current mood**
<!--- For a complete list of markdown compatible emojis check our this git repo (https://gist.github.com/rxaviers/7360908)  --> 
🍓 

**Feedback**

We are so excited you decided to contribute to the Fivetran community dbt package! We continue to work to improve the packages and would greatly appreciate your [feedback](https://www.surveymonkey.com/r/DQ7K7WW) on our existing dbt packages or what you'd like to see next.
