### PR TITLE
feature/materialization-var

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# dbt_salesforce_formula_utils v0.6.5
+## Features
+- Inclusion of the `materialization` argument to the `sfdc_formula_view` macro. The argument is `view` by default. However, if a user wishes to override the materialization then they may do so with this argument.
 # dbt_salesforce_formula_utils v0.6.4
 ## Under the Hood
 - The string `__table` is now appended to the table alias to match with the data provided within the connector. To ensure consistency across the board, the `reserved_table_name` argument is now ignored in place of the `{{source_table}}__table` format. ([#51](https://github.com/fivetran/dbt_salesforce_formula_utils/pull/51))

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ This macro generates the final sql needed to join the Salesforce formula fields 
 * `source_table` (required): The table with which you are joining the formula fields.
 * `source_name` (optional, default 'salesforce'): The dbt source containing the table you want to join with formula fields. Must also contain the `fivetran_formula` table.
 * `fields_to_include` (optional, default is none): If a users wishes to only run the formula fields macro for designated fields then they may be applied within this variable. This variable will ensure the model only generates the sql for the designated fields. 
+* `materialization` (optional, default is `view`): By default the model will be materialized as a view. If you would like to materialize as a table, you can adjust using this argument.
 > Note: If you populate the `fields_to_include` argument then the package will exclusively look for those fields. If you have designated a field to be excluded within the `sfdc_exclude_formulas` variable, then this will be ignored and the field will be included in the final model.
 ----
 

--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -1,5 +1,5 @@
 name: 'salesforce_formula_utils'
-version: '0.6.4'
+version: '0.6.5'
 config-version: 2
 
 require-dbt-version: [">=1.0.0", "<2.0.0"]

--- a/integration_tests/dbt_project.yml
+++ b/integration_tests/dbt_project.yml
@@ -1,6 +1,6 @@
 
 name: 'salesforce_formula_integration_tests'
-version: '0.6.4'
+version: '0.6.5'
 profile: 'integration_tests'
 config-version: 2
 

--- a/macros/sfdc_formula_view.sql
+++ b/macros/sfdc_formula_view.sql
@@ -1,9 +1,9 @@
-{%- macro sfdc_formula_view(source_table, source_name='salesforce', reserved_table_name=source_table, fields_to_include=none) -%}
+{%- macro sfdc_formula_view(source_table, source_name='salesforce', reserved_table_name=source_table, fields_to_include=none, materialization='view') -%}
 
 -- Best practice for this model is to be materialized as view. That is why we have set that here.
 {{
     config(
-        materialized = 'view'
+        materialized = materialization
     )
 }}
 


### PR DESCRIPTION
**Are you a current Fivetran customer?** 
<!--- Please tell us your name, title and company -->
Fivetran created PR

**What change(s) does this PR introduce?** 
<!--- Describe what changes your PR introduces to the package and how to leverage this new feature. -->
Inclusion of the `materialization` argument to the `sfdc_formula_view` macro. The argument is `view` by default. However, if a user wishes to override the materialization then they may do so with this argument.

**Did you update the CHANGELOG?** 
<!--- Please update the new package version’s CHANGELOG entry detailing the changes included in this PR. -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [X] Yes

**Does this PR introduce a breaking change?**
<!--- Does this PR introduce changes that will cause current package users' jobs to fail or require a `--full-refresh`? -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [ ] Yes (please provide breaking change details below.)
- [X] No  (please provide an explanation as to how the change is non-breaking below.)

This simply adds a new argument that is `view` by default (this was the original behavior). This will not cause a breaking change for existing users.

**Did you update the dbt_project.yml files with the version upgrade (please leverage standard semantic versioning)? (In both your main project and integration_tests)** 
<!--- The dbt_project.yml and the integration_tests/dbt_project.yml files contain the version number. Be sure to upgrade it accordingly -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [X] Yes

**Is this PR in response to a previously created Bug or Feature Request**
<!--- If an Issue was created it is helpful to track the progress by linking it in the PR. -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [X] Yes, Issue/Feature #53 
- [ ] No 

Additionally, it was brought up within [this dbt Slack thread](https://getdbt.slack.com/archives/C01D1R2JLLA/p1654631053470459) and would be a good addition to the macro.

**How did you test the PR changes?** 
<!--- Proof of testing is required in order for the PR to be approved. -->
<!--- To check a box, remove the space and insert an x in the box (eg. [x] CircleCi). --> 
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [X] CircleCi <!--- CircleCi testing is only applicable to Fivetran employees. --> 
- [X] Local (please provide additional testing details below)

**Select which warehouse(s) were used to test the PR**
<!--- To check a warehouse remove the space and insert an x in the box (eg. [x] Bigquery). --> 
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- [X] BigQuery
- [X] Redshift
- [X] Snowflake
- [X] Postgres
- [ ] Databricks
- [ ] Other (provide details below)

**Provide an emoji that best describes your current mood**
<!--- For a complete list of markdown compatible emojis check our this git repo (https://gist.github.com/rxaviers/7360908)  --> 
👓 

**Feedback**

We are so excited you decided to contribute to the Fivetran community dbt package! We continue to work to improve the packages and would greatly appreciate your [feedback](https://www.surveymonkey.com/r/DQ7K7WW) on our existing dbt packages or what you'd like to see next.
