### PR TITLE
doc(salesforce): Fix broken link in Formula Utils README

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ vars:
 Once you have created all your desired models and copied/modified the sql snippet into each model you will execute `dbt deps` to install the macro package, then execute `dbt run` to generate the models. Additionally, you can reference the [integration_tests](https://github.com/fivetran/dbt_salesforce_formula_utils/tree/main/integration_tests/models) folder for examples on how to use the macro within your models.
 
 ### Model Creation Automation
-If you have multiple models you need to create, you can also Leverage the [sfdc_formula_model_automation](sfdc_formula_model_automation.sh) script within this project to automatically create models locally via the command line. Below is an example command to copy and edit.
+If you have multiple models you need to create, you can also Leverage the [sfdc_formula_model_automation](https://github.com/fivetran/dbt_salesforce_formula_utils/blob/main/sfdc_formula_model_automation.sh) script within this project to automatically create models locally via the command line. Below is an example command to copy and edit.
 
 ```bash
 source dbt_modules/salesforce_formula_utils/sfdc_formula_model_automation.sh "../path/to/directory" "desired_table_1,desired_table_2,desired_table_infinity"


### PR DESCRIPTION
Closes https://fivetran.height.app/T-347373

Fixes a broken link in the Salesforce Formula Utils README. The original link works only in GitHub and doesn't render correctly in the [embedded README](https://fivetran.com/docs/transformations/data-models/salesforce-data-model/salesforce-formula-utils-model#modelcreationautomation).