### PR TITLE
Fix for syntax error in compiled SQL from sfdc_formula_view_sql macro...

### DIFF
--- a/macros/sfdc_formula_view_sql.sql
+++ b/macros/sfdc_formula_view_sql.sql
@@ -12,14 +12,14 @@
             --The select statement must explicitly query from and join from the source, not the target. The replace filters point the query to the source.
             {% if ' from ' in v %}
                 {%- set v = v | replace(' from ',' from ' + source(source_name,'fivetran_formula') | string ) -%}
-                {% if target.type == 'bigquery' %} {%- set v = v | replace('`fivetran_formula`','') -%} 
+                {% if target.type == 'bigquery' or target.type == 'databricks' %} {%- set v = v | replace('`fivetran_formula`','') -%} 
                 {% elif target.type == 'redshift' %} {%- set v = v | replace('"fivetran_formula"', '') -%} 
                 {% else %} {%- set v = v | replace('fivetran_formula','') -%} {% endif %}
             {% endif %}
 
             {% if ' left join ' in v %}
                 {%- set v = v | replace(' left join ',' left join ' + source(source_name,'fivetran_formula') | string ) -%}
-                {% if target.type == 'bigquery' %} {%- set v = v | replace('`fivetran_formula`','') -%} 
+                {% if target.type == 'bigquery' or target.type == 'databricks' %} {%- set v = v | replace('`fivetran_formula`','') -%} 
                 {% elif target.type == 'redshift' %} {%- set v = v | replace('"fivetran_formula"', '') -%} 
                 {% else %} {%- set v = v | replace('fivetran_formula','') -%} {% endif %}
             {% endif %}


### PR DESCRIPTION
Fixes syntax issue in the compiled SQL from the sfdc_formula_view_sql macro when using Databricks.

**Please provide your name and company**
Andrew Corcoran - West Shore Home

**Link the issue/feature request which this PR is meant to address**
#91 

**Detail what changes this PR introduces and how this addresses the issue/feature request linked above.**
When using the package with Databricks, the sfdc_formula_view_sql macro now uses the same replace filter for `` `fivetran_formula` `` as BigQuery, since the backtick syntax returned from the `source()` function is the same. 

Before:
```sql
select main__table.id, ( opportunity__alias.secondary_campaign_c ) as secondary_campaign_c 
from `fivetran`.`salesforce`.``service_appointment as main__table 
left join `fivetran`.`salesforce`.``opportunity as opportunity__alias on main__table.opportunity_c = opportunity__alias.id
```
After:
```sql
select main__table.id, ( opportunity__alias.secondary_campaign_c ) as secondary_campaign_c 
from `fivetran`.`salesforce`.service_appointment as main__table 
left join `fivetran`.`salesforce`.opportunity as opportunity__alias on main__table.opportunity_c = opportunity__alias.id
```

**How did you validate the changes introduced within this PR?**
Local testing with `dbt compile`, Databricks warehouse testing with `dbt run`

**Which warehouse did you use to develop these changes?**
Databricks

**Did you update the CHANGELOG?**
- [ ] Yes

**Did you update the dbt_project.yml files with the version upgrade (please leverage standard semantic versioning)? (In both your main project and integration_tests)**
- [ ] Yes

**Provide an emoji that best describes your current mood**
🔨 