### PR TITLE
Doc(dbt_salesforce_formula_utils README KCS): Update information about output schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,15 @@ This package enables you to accurately map Salesforce formulas to existing table
 > Additionally, note that this solution **does not support** formula field history mode. The formula fields recreated from this package will only use the most recent formula available in your Salesforce environment.
 
 ### Output schema
-Final output tables are generated in the following target schema:
-
+ Final output tables are generated in the following target schema in most cases:
 ```
 <your_database>.<connector/schema_name>_salesforce_formula_utils
 ```
 
+For Quickstart schema names edited after March 2027, Final output tables are generated using the Output schema value shown in your Quickstart transformation settings 
+```
+<your_database>.<quickstart_output_schema>
+```
 ### Final output tables
 
 By default, this package materializes the following final tables:

--- a/README.md
+++ b/README.md
@@ -22,15 +22,16 @@ This package enables you to accurately map Salesforce formulas to existing table
 > Additionally, note that this solution **does not support** formula field history mode. The formula fields recreated from this package will only use the most recent formula available in your Salesforce environment.
 
 ### Output schema
- Final output tables are generated in the following target schema in most cases:
+Final output tables are generated in the following target schema for projects created on or after March 23, 2026:
 ```
-<your_database>.<connector/schema_name>_salesforce_formula_utils
+<your_database>.<connector/schema_name>_reports
 ```
 
-For Quickstart schema names edited after March 2027, Final output tables are generated using the Output schema value shown in your Quickstart transformation settings 
+Final output tables are generated in the following target schema for projects created before March 23, 2026:
 ```
-<your_database>.<quickstart_output_schema>
+<your_database>.<connector/schema_name>_quickstart
 ```
+
 ### Final output tables
 
 By default, this package materializes the following final tables:


### PR DESCRIPTION
**Please provide your name and company**
- author_email: tatanya.klass@fivetran.com

**Link the issue/feature request which this PR is meant to address**
- Starting March 2026, we added a [new feature](https://fivetran.com/docs/changelog/2026/march-2026#customnamingconventionforquickstartdatamodels) that made Quickstart schema names editable. This is not reflected in the Output schema section of the README dbt_salesforce_formula_utils package
-  I'm filing this for just the dbt_salesforce_formula_utils package, but a similar edit might be needed on all other dbt packages that have Quickstart models.

**Detail what changes this PR introduces and how this addresses the issue/feature request linked above.**
- The current content shows all target schema's ending with "__salesforce_formula_utils", which might not be true after Quickstart customers edit their schema. 

**How did you validate the changes introduced within this PR?**
- The current content of this README varies from what we explain here: [Formula Fields - Salesforce Quickstart Model](https://fivetran.com/docs/transformations/data-models/salesforce-formula-fields#howcaniaccessmyformulafields)

**Which warehouse did you use to develop these changes?**
- I have a BigQuery destination, but this change is not warehouse specific because it only affects the README

**Did you update the CHANGELOG?**
<!--- Please update the new package version’s CHANGELOG entry detailing the changes included in this PR. -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- This change was noted in our [general changelog,](https://fivetran.com/docs/changelog/2026/march-2026#customnamingconventionforquickstartdatamodels) but I don't believe it has been mentioned in the changelog for this specific package.

**Did you update the dbt_project.yml files with the version upgrade (please leverage standard semantic versioning)? (In both your main project and integration_tests)**
<!--- The dbt_project.yml and the integration_tests/dbt_project.yml files contain the version number. Be sure to upgrade it accordingly -->
<!--- To select a checkbox you simply need to add an "x" with no spaces between the brackets (eg. [x] Yes). -->
- N/A

**Typically there are additional maintenance changes required before this will be ready for an upcoming release. Are you comfortable with the Fivetran team making a few commits directly to your branch?**
<!--- If you select Yes this will help expedite your PR in case there are small changes required before approval. We encourage you not to use this branch in a production environment as we may make additional updates.  -->
<!--- If you select No, we will not make any changes directly to your branch and will either communicate any planned changes via the PR thread or will merge your PR into a separate branch so we may make changes without modifying your branch.. -->
- [X] Yes
- [ ] No

**If you had to summarize this PR in an emoji, which would it be?**
<!--- For a complete list of markdown compatible emojis check our this git repo (https://gist.github.com/rxaviers/7360908)  --> 
:transformer-party:

**Feedback**

We are so excited you decided to contribute to the Fivetran community dbt package! We continue to work to improve the packages and would greatly appreciate your [feedback](https://www.surveymonkey.com/r/DQ7K7WW) on our existing dbt packages or what you'd like to see next.

**PR Template** 
- [Community Pull Request Template](?expand=1&template=pull_request_template.md) (default)

- [Maintainer Pull Request Template](?expand=1&template=maintainer_pull_request_template.md) (to be used by maintainers)
