### PR TITLE
feat(sfdc_formula_view): add query_engine inference and use run_query for non-Redshift adapters

### DIFF
--- a/macros/sfdc_formula_view.sql
+++ b/macros/sfdc_formula_view.sql
@@ -1,6 +1,7 @@
-{%- macro sfdc_formula_view(source_table, source_name='salesforce', materialization='view', using_quoted_identifiers=False, full_statement_version=true, reserved_table_name=none, fields_to_include=none) -%}
+{%- macro sfdc_formula_view(source_table, source_name='salesforce', materialization='view', using_quoted_identifiers=False, full_statement_version=true, reserved_table_name=none, fields_to_include=none, query_engine=none) -%}
 
 -- Best practice for this model is to be materialized as view. That is why we have set that here.
+-- Note: catalog-linked Snowflake databases may require materialization='table' because views are unsupported.
 {{
     config(
         materialized = materialization
@@ -13,6 +14,23 @@
     See_full_model_error_in_log
 
 {% else %}
+
+    {# Resolve query engine: explicit arg > project var > adapter inference #}
+    {%- set selected_query_engine = query_engine or var('salesforce_formula_query_engine', none) -%}
+    {%- if selected_query_engine is none -%}
+        {%- if target.type == 'snowflake' -%}
+            {%- set selected_query_engine = 'Snowflake' -%}
+        {%- elif target.type == 'bigquery' -%}
+            {%- set selected_query_engine = 'BigQuery' -%}
+        {%- elif target.type in ('databricks', 'spark') -%}
+            {%- set selected_query_engine = 'Databricks' -%}
+        {%- elif target.type == 'redshift' -%}
+            {%- set selected_query_engine = 'Redshift' -%}
+        {%- else -%}
+            {%- set selected_query_engine = 'Generic' -%}
+        {%- endif -%}
+    {%- endif -%}
+
     {% if target.type == 'redshift' %}
 
         {# Specifically for redshift we need to check if the model_large column exists and has non-null values. #}
@@ -38,22 +56,54 @@
         {%- endfor -%}
         {%- set model_column_datatype = ns.column_type -%}
 
+        {%- set object_column = adapter.quote('object') if using_quoted_identifiers else 'object' -%}
+        {%- set model_col = adapter.quote(model_column_name) if using_quoted_identifiers else model_column_name -%}
+
+        {%- set table_results = dbt_utils.get_column_values(
+            table=source(source_name, 'fivetran_formula_model'),
+            column=model_col,
+            where=object_column ~ " = '" ~ source_table ~ "'"
+        ) -%}
+
+        {# Use dbt's built-in JSON parsing to handle all escape sequences for SUPER datatype #}
+        {{ fromjson(table_results[0]) if model_column_datatype == 'super' else table_results[0] }}
+
     {% else %}
+
+        {# For non-Redshift adapters, use run_query to avoid load_relation failures on catalog-linked sources. #}
         {%- set model_column_name = 'MODEL' if target.type == 'snowflake' else 'model' -%}
-        {%- set model_column_datatype = 'string' -%}
+        {%- set object_column = adapter.quote('OBJECT' if target.type == 'snowflake' else 'object') if using_quoted_identifiers else 'object' -%}
+        {%- set model_col = adapter.quote(model_column_name) if using_quoted_identifiers else model_column_name -%}
+        {%- set query_engine_column = adapter.quote('query_engine') if using_quoted_identifiers else 'query_engine' -%}
+        {%- set synced_column = adapter.quote('_fivetran_synced') if using_quoted_identifiers else '_fivetran_synced' -%}
+
+        {%- set formula_sql -%}
+            select {{ model_col }} as model_sql
+            from {{ source(source_name, 'fivetran_formula_model') }}
+            where {{ object_column }} = '{{ source_table | replace("'", "''") }}'
+              and {{ query_engine_column }} = '{{ selected_query_engine | replace("'", "''") }}'
+              and {{ model_col }} is not null
+            order by {{ synced_column }} desc
+            limit 1
+        {%- endset -%}
+
+        {%- if execute -%}
+            {%- set formula_results = run_query(formula_sql) -%}
+
+            {%- if formula_results is none or formula_results.rows | length == 0 -%}
+                {{ exceptions.raise_compiler_error(
+                    "No Salesforce formula model found for object '" ~ source_table ~
+                    "' and query_engine '" ~ selected_query_engine ~ "'. " ~
+                    "Pass query_engine='...' to override adapter inference, or set the salesforce_formula_query_engine project var."
+                ) }}
+            {%- endif -%}
+
+            {{ formula_results.columns[0].values()[0] }}
+        {%- else -%}
+            select 1 as compile_placeholder where false
+        {%- endif -%}
+
     {% endif %}
-
-    {%- set object_column = adapter.quote('OBJECT' if target.type == 'snowflake' else 'object') if using_quoted_identifiers else 'object' -%}
-    {%- set model_col = adapter.quote(model_column_name) if using_quoted_identifiers else model_column_name -%}
-
-    {%- set table_results = dbt_utils.get_column_values(
-        table=source(source_name, 'fivetran_formula_model'),
-        column=model_col,
-        where=object_column ~ " = '" ~ source_table ~ "'"
-    ) -%}
-
-    {# Use dbt's built-in JSON parsing to handle all escape sequences for SUPER datatype #}
-    {{ fromjson(table_results[0]) if model_column_datatype == 'super' else table_results[0] }}
 
 {% endif %}
 {%- endmacro -%}


### PR DESCRIPTION
## Summary

This PR updates `sfdc_formula_view` to select the generated formula model by query engine and avoid a relation-existence check that can fail for Snowflake catalog-linked databases.

The Salesforce connector produces multiple rows in `fivetran_formula_model` for the same Salesforce object — one per query engine. The previous macro filtered only by object and used `dbt_utils.get_column_values`, whose `load_relation` check can return `None` for catalog-linked (Iceberg/Managed Data Lake) sources even when direct SQL against the source succeeds.

**Changes:**
- Adds an optional `query_engine` argument to `sfdc_formula_view`
- Adds a `salesforce_formula_query_engine` project var as a fallback
- Infers query engine from `target.type` if neither is provided (`snowflake` → `Snowflake`, `bigquery` → `BigQuery`, `databricks`/`spark` → `Databricks`, `redshift` → `Redshift`, else `Generic`)
- Replaces `dbt_utils.get_column_values` on the non-Redshift path with a direct `run_query` call that filters by both `object` and `query_engine`
- Preserves all existing Redshift `model_large` / SUPER behavior unchanged
- Preserves the `materialization` argument; documents that catalog-linked Snowflake databases require `materialization='table'` because view creation is unsupported

## Validation

Smoke-tested against a Snowflake catalog-linked database backed by Fivetran Managed Data Lake using [fivetran/dbt_snowflake_iceberg_writer](https://github.com/fivetran/dbt_snowflake_iceberg_writer):

```sh
dbt run --select smoke_salesforce_formula_account smoke_salesforce_formula_user_role
# 2 pass, 0 fail
```

Both models materialized as `BASE TABLE` relations against `lowery_linked_writer.dbt_core_dev`.

## Test plan

- [ ] Confirm `dbt parse` passes with updated macro
- [ ] Confirm `dbt compile --select smoke_salesforce_formula_account smoke_salesforce_formula_user_role` passes
- [ ] Confirm `dbt run --select smoke_salesforce_formula_account smoke_salesforce_formula_user_role` passes with `materialization='table'` on Snowflake catalog-linked database
- [ ] Confirm existing Redshift integration tests still pass
- [ ] Add/update integration tests: multiple `query_engine` rows for same object selects adapter-specific row; explicit `query_engine` override works; default adapter inference works

🤖 Generated with [Claude Code](https://claude.com/claude-code)